### PR TITLE
Require Field Group and Video Embed Field modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,8 @@
         "drupal/twig_field_value": "^2.0",
         "drupal/twig_tweak": "^3.1",
         "drupal/metatag": "2.2",
-        "drupal/pathauto": "1.14"
+        "drupal/pathauto": "1.14",
+        "drupal/field_group": "^4.0",
+        "drupal/video_embed_field": "^3.0"
     }
 }


### PR DESCRIPTION
Fixes #3

Also related to [the issue with config export/import on EAS](https://github.com/gatech-arcs/web-eas/issues/77): once the missing config files were put back in, new errors surfaced due to the Video Embed Field not being installed.